### PR TITLE
Fix code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/backend/app/routes/extratos.py
+++ b/backend/app/routes/extratos.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, request, jsonify
+from flask import Blueprint, request, jsonify, current_app as app
 from backend.app.services.extrato_service import importar_extrato
 from backend.app.schemas.lancamento import lancamentos_schema
 
@@ -23,6 +23,7 @@ def importar(conta_bancaria_id):
                 'lancamentos': lancamentos_schema.dump(lancamentos)
             }), 201
         except Exception as e:
-            return jsonify({'error': str(e)}), 500
+            app.logger.error('An error occurred while importing extrato', exc_info=True)
+            return jsonify({'error': 'An internal error has occurred!'}), 500
     else:
         return jsonify({'error': 'Formato de arquivo inválido. Por favor, envie um arquivo CSV.'}), 400


### PR DESCRIPTION
Fixes [https://github.com/Uesleyribeiro/Financeiro_systema1/security/code-scanning/2](https://github.com/Uesleyribeiro/Financeiro_systema1/security/code-scanning/2)

To fix the problem, we need to ensure that detailed exception information is not exposed to the user. Instead, we should log the exception details on the server and return a generic error message to the user. This can be achieved by modifying the exception handling block to log the exception and return a generic error message.

1. Import the `logging` module to enable logging of exceptions.
2. Replace the line that returns the exception message with a logging statement and a generic error message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
