### PR TITLE
Fix code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/backend/run.py
+++ b/backend/run.py
@@ -199,4 +199,5 @@ def internal_error(error):
     return jsonify({"error": "Erro interno do servidor"}), 500
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    debug_mode = os.getenv('FLASK_DEBUG', 'False').lower() in ['true', '1', 't']
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Fixes [https://github.com/Uesleyribeiro/Financeiro_systema1/security/code-scanning/1](https://github.com/Uesleyribeiro/Financeiro_systema1/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is by using an environment variable to control the debug mode. This way, we can set the debug mode to `True` during development and `False` during production.

1. Modify the `app.run()` method to use an environment variable to determine the debug mode.
2. Update the code to read the environment variable and set the debug mode accordingly.
3. Ensure that the environment variable is set appropriately in the deployment environment.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
